### PR TITLE
Added scripts to reproduce SEMA 1D results

### DIFF
--- a/notebooks/SEMA_1D_Original.ipynb
+++ b/notebooks/SEMA_1D_Original.ipynb
@@ -1,0 +1,498 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "machine_shape": "hm",
+      "gpuType": "V28"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "TPU"
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install fair-esm"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "HuD3anlJHTRp",
+        "outputId": "0063ee9e-8438-4c97-ccc7-35e5cc89c1ee"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting fair-esm\n",
+            "  Downloading fair_esm-2.0.0-py3-none-any.whl.metadata (37 kB)\n",
+            "Downloading fair_esm-2.0.0-py3-none-any.whl (93 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m93.1/93.1 kB\u001b[0m \u001b[31m3.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: fair-esm\n",
+            "Successfully installed fair-esm-2.0.0\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "ynvoC_RlF_1H"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "os.environ['TORCH_HOME'] = \"../torch_hub\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import scipy\n",
+        "import sklearn\n",
+        "import esm\n",
+        "\n",
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "\n",
+        "import torch\n",
+        "from torch.utils.data import Dataset\n",
+        "from torch import nn\n",
+        "import math\n",
+        "\n",
+        "import transformers\n",
+        "from transformers.modeling_outputs import SequenceClassifierOutput\n",
+        "from transformers import Trainer, TrainingArguments, EvalPrediction\n",
+        "\n",
+        "from esm.pretrained import load_model_and_alphabet_hub\n",
+        "\n",
+        "from sklearn.metrics import r2_score, mean_squared_error"
+      ],
+      "metadata": {
+        "id": "Yyv2veP8HMuF"
+      },
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class PDB_Dataset(Dataset):\n",
+        "    \"\"\"\n",
+        "    A class to represent a sutable data set for model.\n",
+        "\n",
+        "    convert original pandas data frame to model set,\n",
+        "    where 'token ids' is ESM-1v embedings corresponed to protein sequence (max length 1022 AA)\n",
+        "    and 'lables' is a contact number values\n",
+        "    Attributes:\n",
+        "        df (pandas.DataFrame): dataframe with two columns:\n",
+        "                0 -- preotein sequence in string ('GLVM') or list (['G', 'L', 'V', 'M']) format\n",
+        "                1 -- contcat number values in list [0, 0.123, 0.23, -100, 1.34] format\n",
+        "        esm1v_batch_converter (function):\n",
+        "                    ESM function callable to convert an unprocessed (labels + strings) batch to a\n",
+        "                    processed (labels + tensor) batch.\n",
+        "        label_type (str):\n",
+        "                type of model: regression or binary\n",
+        "\n",
+        "    \"\"\"\n",
+        "    def __init__(self, df, label_type ='regression'):\n",
+        "        \"\"\"\n",
+        "        Construct all the necessary attributes to the PDB_Database object.\n",
+        "\n",
+        "        Parameters:\n",
+        "            df (pandas.DataFrame): dataframe with two columns:\n",
+        "                0 -- protein sequence in string ('GLVM') or list (['G', 'L', 'V', 'M']) format\n",
+        "                1 -- contcat number values in list [0, 0.123, 0.23, -100, 1.34] format\n",
+        "            label_type (str):\n",
+        "                type of model: regression or binary\n",
+        "        \"\"\"\n",
+        "        self.df = df\n",
+        "        _, esm1v_alphabet = esm.pretrained.esm2_t6_8M_UR50D()\n",
+        "        self.esm1v_batch_converter = esm1v_alphabet.get_batch_converter()\n",
+        "        self.label_type = label_type\n",
+        "\n",
+        "    def __getitem__(self, idx):\n",
+        "        item = {}\n",
+        "        _, _, esm1b_batch_tokens = self.esm1v_batch_converter([('' , ''.join(self.df.iloc[idx,0])[:1022])])\n",
+        "        item['token_ids'] = esm1b_batch_tokens\n",
+        "        item['labels'] = torch.unsqueeze(torch.FloatTensor(self.df.iloc[idx, 1][:1022]),0).to(torch.float64)\n",
+        "\n",
+        "        return item\n",
+        "\n",
+        "    def __len__(self):\n",
+        "        return len(self.df)"
+      ],
+      "metadata": {
+        "id": "1uPtkpDGHht4"
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class ESM1vForTokenClassification(nn.Module):\n",
+        "\n",
+        "    def __init__(self, num_labels = 2, pretrained_no = 1):\n",
+        "        super().__init__()\n",
+        "        self.num_labels = num_labels\n",
+        "        self.model_name = esm.pretrained.esm2_t6_8M_UR50D()\n",
+        "\n",
+        "        self.esm1v, self.esm1v_alphabet = esm.pretrained.esm2_t6_8M_UR50D()#load_model_and_alphabet_hub(self.model_name)\n",
+        "        self.classifier = nn.Linear(320, self.num_labels)\n",
+        "\n",
+        "    def forward(self, token_ids, labels = None):\n",
+        "\n",
+        "        outputs = self.esm1v.forward(token_ids, repr_layers=[6])['representations'][6]\n",
+        "        outputs = outputs[:,1:-1,:]\n",
+        "        logits = self.classifier(outputs)\n",
+        "\n",
+        "        return SequenceClassifierOutput(logits=logits)"
+      ],
+      "metadata": {
+        "id": "mCO-uL25IcE-"
+      },
+      "execution_count": 31,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_metrics_regr(p: EvalPrediction):\n",
+        "\n",
+        "    preds = p.predictions[:,:,1]\n",
+        "\n",
+        "    batch_size, seq_len = preds.shape\n",
+        "    out_labels, out_preds = [], []\n",
+        "\n",
+        "    for i in range(batch_size):\n",
+        "        for j in range(seq_len):\n",
+        "            if p.label_ids[i, j] > -1:\n",
+        "                out_labels.append(p.label_ids[i][j])\n",
+        "                out_preds.append(preds[i][j])\n",
+        "\n",
+        "    out_labels_regr = out_labels#[math.log(t+1) for t in out_labels]\n",
+        "\n",
+        "\n",
+        "    return {\n",
+        "        \"pearson_r\": scipy.stats.pearsonr(out_labels_regr, out_preds)[0],\n",
+        "        \"mse\": mean_squared_error(out_labels_regr, out_preds),\n",
+        "        \"r2_score\": r2_score(out_labels_regr, out_preds)\n",
+        "    }"
+      ],
+      "metadata": {
+        "id": "NkQgNeWHIija"
+      },
+      "execution_count": 18,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def model_init_1():\n",
+        "    return ESM1vForTokenClassification(pretrained_no = 1)#.cuda()"
+      ],
+      "metadata": {
+        "id": "KSUxdPLmIjCX"
+      },
+      "execution_count": 19,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class MaskedMSELoss(torch.nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super(MaskedMSELoss, self).__init__()\n",
+        "\n",
+        "    def forward(self, inputs, target, mask):\n",
+        "        diff2 = (torch.flatten(inputs[:,:,1]) - torch.flatten(target)) ** 2.0 * torch.flatten(mask)\n",
+        "        result = torch.sum(diff2) / torch.sum(mask)\n",
+        "        if torch.sum(mask)==0:\n",
+        "            return torch.sum(diff2)\n",
+        "        else:\n",
+        "            #print('loss:', result)\n",
+        "            return result"
+      ],
+      "metadata": {
+        "id": "VTHTEYTaIlb2"
+      },
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class MaskedRegressTrainer(Trainer):\n",
+        "  def compute_loss(self, model, inputs, return_outputs=False):\n",
+        "      labels = inputs.pop(\"labels\")\n",
+        "      labels = labels.squeeze().detach().cpu().numpy().tolist()\n",
+        "      labels = [math.log(t+1) if t!=-100 else -100 for t in labels]\n",
+        "      labels = torch.unsqueeze(torch.FloatTensor(labels), 0)#.cuda()\n",
+        "      masks = ~torch.eq(labels, -100)#.cuda()\n",
+        "\n",
+        "\n",
+        "\n",
+        "      #masks = inputs.pop(\"masks\")\n",
+        "      outputs = model(**inputs)\n",
+        "      logits = outputs.logits\n",
+        "\n",
+        "      loss_fn = MaskedMSELoss()\n",
+        "\n",
+        "      loss = loss_fn(logits, labels, masks)\n",
+        "\n",
+        "      return (loss, outputs) if return_outputs else loss"
+      ],
+      "metadata": {
+        "id": "JIb20zVuInY-"
+      },
+      "execution_count": 21,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def collator_fn(x):\n",
+        "    if len(x)==1:\n",
+        "        return x[0]\n",
+        "    print('x:', x)\n",
+        "    return x"
+      ],
+      "metadata": {
+        "id": "UkrzO5bEIqQ1"
+      },
+      "execution_count": 22,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import urllib.request\n",
+        "\n",
+        "# Base URL and file paths\n",
+        "base_url = 'https://raw.githubusercontent.com/AIRI-Institute/SEMAi/main/epitopes_prediction/data/sema_1.0/'\n",
+        "train_data_url = base_url + 'train_set.csv'\n",
+        "test_data_url = base_url + 'test_set.csv'\n",
+        "\n",
+        "# Create the directory if it doesn't exist\n",
+        "directory = '../data'\n",
+        "if not os.path.exists(directory):\n",
+        "    os.makedirs(directory)\n",
+        "\n",
+        "# Function to download and save the file\n",
+        "def download_file(url, save_path):\n",
+        "    urllib.request.urlretrieve(url, save_path)\n",
+        "    print(f\"Downloaded {url} to {save_path}\")\n",
+        "\n",
+        "# Download the train and test data\n",
+        "train_data_path = os.path.join(directory, 'train_set.csv')\n",
+        "test_data_path = os.path.join(directory, 'test_set.csv')\n",
+        "\n",
+        "download_file(train_data_url, train_data_path)\n",
+        "download_file(test_data_url, test_data_path)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "eFImF3xqJPcz",
+        "outputId": "3fb069c5-e543-45ca-9c2b-8dd89059b727"
+      },
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloaded https://raw.githubusercontent.com/AIRI-Institute/SEMAi/main/epitopes_prediction/data/sema_1.0/train_set.csv to ../data/train_set.csv\n",
+            "Downloaded https://raw.githubusercontent.com/AIRI-Institute/SEMAi/main/epitopes_prediction/data/sema_1.0/test_set.csv to ../data/test_set.csv\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "train_set = pd.read_csv('../data/train_set.csv')\n",
+        "train_set = train_set.groupby('pdb_id_chain').agg({'resi_pos': list,\n",
+        "                                 'resi_aa': list,\n",
+        "                                 'contact_number': list}).reset_index()\n",
+        "## the first run will take about 5-10 minutes, because esm weights should be downloaded\n",
+        "train_ds = PDB_Dataset(train_set[['resi_aa', 'contact_number']],\n",
+        "                      label_type ='regression')\n",
+        "\n",
+        "test_set = pd.read_csv('../data/test_set.csv')\n",
+        "test_set = test_set.groupby('pdb_id_chain').agg({'resi_pos': list,\n",
+        "                                 'resi_aa': list,\n",
+        "                                 'contact_number_binary': list}).reset_index()\n",
+        "test_ds = PDB_Dataset(test_set[['resi_aa', 'contact_number_binary']],\n",
+        "                      label_type ='regression')"
+      ],
+      "metadata": {
+        "id": "Jmv95ZJFIsDX"
+      },
+      "execution_count": 24,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "training_args = TrainingArguments(\n",
+        "    output_dir='./results_fold' ,          # output directory\n",
+        "    num_train_epochs=2,              # total number of training epochs\n",
+        "    per_device_train_batch_size=1,   # batch size per device during training\n",
+        "    per_device_eval_batch_size=1,   # batch size for evaluation\n",
+        "    warmup_steps=0,                # number of warmup steps for learning rate scheduler\n",
+        "    learning_rate=1e-05,             # learning rate\n",
+        "    weight_decay=0.0,                # strength of weight decay\n",
+        "    logging_dir='./logs',            # directory for storing logs\n",
+        "    logging_steps=200,               # How often to print logs\n",
+        "    save_strategy = \"no\",\n",
+        "    do_train=True,                   # Perform training\n",
+        "    do_eval=True,                    # Perform evaluation\n",
+        "    evaluation_strategy=\"epoch\",     # evalute after each epoch\n",
+        "    gradient_accumulation_steps=1,  # total number of steps before back propagation\n",
+        "    fp16=False,                       # Use mixed precision\n",
+        "    run_name=\"PDB_binary\",      # experiment name\n",
+        "    seed=42,                         # Seed for experiment reproducibility\n",
+        "    load_best_model_at_end=False,\n",
+        "    metric_for_best_model=\"eval_accuracy\",\n",
+        "    greater_is_better=True,\n",
+        "    use_cpu = True\n",
+        "    #remove_unused_columns=False\n",
+        ")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "hfONUtt4JVHz",
+        "outputId": "14d9c777-cc1b-47ca-a089-3009067b796a"
+      },
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.10/dist-packages/transformers/training_args.py:1525: FutureWarning: `evaluation_strategy` is deprecated and will be removed in version 4.46 of 🤗 Transformers. Use `eval_strategy` instead\n",
+            "  warnings.warn(\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#create direactory to weights storage\n",
+        "if not os.path.exists(\"../models/\"):\n",
+        "    os.makedirs(\"../models/\")"
+      ],
+      "metadata": {
+        "id": "SOvsckjHMent"
+      },
+      "execution_count": 26,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def model_init_1():\n",
+        "    return ESM1vForTokenClassification(pretrained_no = 1)#.cuda()"
+      ],
+      "metadata": {
+        "id": "BWLDrZa7Mqgf"
+      },
+      "execution_count": 27,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "trainer = MaskedRegressTrainer(\n",
+        "    model=model_init_1(),                   # the instantiated 🤗 Transformers model to be trained\n",
+        "    args=training_args,                     # training arguments, defined above\n",
+        "    train_dataset=train_ds,                 # training dataset\n",
+        "    eval_dataset=test_ds,                   # evaluation dataset\n",
+        "    data_collator = collator_fn,\n",
+        "    compute_metrics = compute_metrics_regr,    # evaluation metrics\n",
+        ")\n",
+        "\n",
+        "trainer.train()\n",
+        "\n",
+        "#save weights\n",
+        "torch.save(trainer.model.state_dict(), \"../models/sema_1d_ESM2_8M_0_old.pth\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 138
+        },
+        "id": "Psixe5V4Mg_G",
+        "outputId": "3a6922d9-f086-47ad-9683-7df7df0de2a6"
+      },
+      "execution_count": 33,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "\n",
+              "    <div>\n",
+              "      \n",
+              "      <progress value='1566' max='1566' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+              "      [1566/1566 04:06, Epoch 2/2]\n",
+              "    </div>\n",
+              "    <table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              " <tr style=\"text-align: left;\">\n",
+              "      <th>Epoch</th>\n",
+              "      <th>Training Loss</th>\n",
+              "      <th>Validation Loss</th>\n",
+              "      <th>Pearson R</th>\n",
+              "      <th>Mse</th>\n",
+              "      <th>R2 Score</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <td>1</td>\n",
+              "      <td>0.255100</td>\n",
+              "      <td>0.164319</td>\n",
+              "      <td>0.158354</td>\n",
+              "      <td>0.164540</td>\n",
+              "      <td>-1.257513</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <td>2</td>\n",
+              "      <td>0.230600</td>\n",
+              "      <td>0.155422</td>\n",
+              "      <td>0.164969</td>\n",
+              "      <td>0.156104</td>\n",
+              "      <td>-1.141769</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table><p>"
+            ]
+          },
+          "metadata": {}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Added model training notebook file. The notebook was ran on Google Colab and produced on-par result with the training notebooks of the SEMA 1D model.

Ours:
![Screenshot 2024-09-29 at 3 56 40 PM](https://github.com/user-attachments/assets/48030344-915f-4f2c-bf6a-1ed5a93a85ee)

SEMA's:
![Screenshot 2024-09-29 at 4 07 29 PM](https://github.com/user-attachments/assets/eaa51825-1883-4c39-8891-5c737482783f)

